### PR TITLE
fix: add directories to be ignored to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 __mocks__/
 __tests__/
+.github/
+.husky/
 src/
 .commitlintrc.js
 .eslintignore


### PR DESCRIPTION
`.husky` and `.github` directories don't have to  distribute to users.