### PR TITLE
fix: modified glob pattern to catch more licenses

### DIFF
--- a/__tests__/integration/extract/basic-cases/__snapshots__/basic-cases.test.ts.snap
+++ b/__tests__/integration/extract/basic-cases/__snapshots__/basic-cases.test.ts.snap
@@ -41,6 +41,13 @@ foo
 license: MIT
 foo - license text - line1
 foo - license text - line2
+
+
+
+qux
+license: MIT
+qux - license text - line1
+qux - license text - line2
 "
 `;
 
@@ -56,6 +63,13 @@ foo
 license: MIT
 foo - license text - line1
 foo - license text - line2
+
+
+
+qux
+license: MIT
+qux - license text - line1
+qux - license text - line2
 "
 `;
 
@@ -71,5 +85,12 @@ foo
 license: MIT
 foo - license text - line1
 foo - license text - line2
+
+
+
+qux
+license: MIT
+qux - license text - line1
+qux - license text - line2
 "
 `;

--- a/__tests__/integration/extract/basic-cases/node_modules/qux/LICENSE-MIT.txt
+++ b/__tests__/integration/extract/basic-cases/node_modules/qux/LICENSE-MIT.txt
@@ -1,0 +1,2 @@
+qux - license text - line1
+qux - license text - line2

--- a/__tests__/integration/extract/basic-cases/node_modules/qux/package.json
+++ b/__tests__/integration/extract/basic-cases/node_modules/qux/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "qux",
+  "version": "4.5.6",
+  "license": "MIT"
+}

--- a/__tests__/integration/extract/basic-cases/package.json
+++ b/__tests__/integration/extract/basic-cases/package.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "foo": "*",
     "bar": "*",
-    "baz": "*"
+    "baz": "*",
+    "qux": "*"
   },
   "devDependencies": {
     "@dev/foo": "*",

--- a/src/functions/getLicenseText.ts
+++ b/src/functions/getLicenseText.ts
@@ -47,10 +47,10 @@ export const getLicenseText = async (
   }
 
   // TODO: read the file specified by "SEE LICENSE IN"
-  const licensePattern = `${depPath}/LICEN@(S|C)E?(.*)`;
+  const licensePattern = `${depPath}/LICEN@(S|C)E?(-MIT)?(.*)`;
 
   const res = glob.sync(licensePattern, { nocase: true });
-  if (res.length) {
+  if (res.length === 1) {
     return {
       licenseTextPath: res[0],
       licenseText: readFile(res[0]),


### PR DESCRIPTION
I modified glob pattern to catch more licenses like LICESE-MIT.txt 