### PR TITLE
feat: add --config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Option for [`workspace` option](https://docs.npmjs.com/cli/v8/commands/npm-query
 Specify which package manager to use `npm` or `pnpm`.
 Automatically detected if you are running the command with `npm run`, `npx`, or `pnpm run`.
 
+#### `-c`, `--config`
+
+**default: (./license-manager.config.js)**
+
+Config file path.
+
 ### Options for `analyze` command
 
 #### `-l`, `--allowLicense`
@@ -132,6 +138,7 @@ Based on the results of npm query, and some fields be added.
 
 You can write all settings to `license-manager.config.js`.  
 If `license-manager.config.js` exists in the current directory, it is automatically loaded.  
+You can change the file path with the --config option.
 CLI options take precedence, but license and package specifications are merged.  
 And you can also specify a override function in case the license and license text cannot be detected.
 

--- a/__tests__/integration/analyze/override-license/awesome-config.js
+++ b/__tests__/integration/analyze/override-license/awesome-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  overrideLicense: () => {
+    console.log("load awesome-config.js");
+    return "OVERRIDE_LICENSE";
+  },
+};

--- a/__tests__/integration/analyze/override-license/override-license.test.ts
+++ b/__tests__/integration/analyze/override-license/override-license.test.ts
@@ -20,5 +20,19 @@ describe("analyze : override-licenses", () => {
     });
 
     expect(console.log).toBeCalledWith(pc.green("✅ All dependencies confirmed"));
+    expect(console.log).toBeCalledWith("💡 Detected license-manager.config.js");
+  });
+
+  it("apply specified config file", async () => {
+    await analyze({
+      ...analyzeDefaultOption,
+      allowLicenses: ["OVERRIDE_LICENSE"],
+      allowPackages: [],
+      configFilePath: "awesome-config.js",
+    });
+
+    expect(console.log).toBeCalledWith(pc.green("✅ All dependencies confirmed"));
+    expect(console.log).toBeCalledWith("💡 Detected awesome-config.js");
+    expect(console.log).toBeCalledWith("load awesome-config.js");
   });
 });

--- a/__tests__/integration/extract/override-license-text/override-license-text.test.ts
+++ b/__tests__/integration/extract/override-license-text/override-license-text.test.ts
@@ -37,5 +37,7 @@ describe("extract : override-license-text", () => {
     expect(console.log).toBeCalledWith(pc.green(`✅ Extracted to ${expectedOutputPath}`));
 
     expect(memfs.readFileSync(expectedOutputPath).toString("utf-8")).toMatchSnapshot();
+
+    expect(console.log).toBeCalledWith("💡 Detected license-manager.config.js");
   });
 });

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -14,10 +14,15 @@ export type AnalyzeArgs = {
   packageManager: string;
 };
 
-export const analyze = async (cliArgs: AnalyzeArgs) => {
+export const analyze = async ({
+  configFilePath,
+  ...cliArgs
+}: AnalyzeArgs & {
+  configFilePath?: string;
+}) => {
   console.log("🔎 Analyzing dependencies...");
 
-  const config = await loadConfigScript();
+  const config = await loadConfigScript(configFilePath);
   const args = mergeConfig(cliArgs, config);
   const unreadLicenseTextPattern = [/.*/];
   const dependencies = await aggregate(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ program
   .option("-l, --allowLicense <string...>", "allow licenses")
   .option("-p, --allowPackage <string...>", "allow packages (allowed without license)")
   .option("-m, --packageManager <npm|pnpm>", "package manager used to analyze licenses (default: auto detect)")
+  .option("-c, --config <path>", "config path. defaults to ./license-manager.config.js")
   .action((options) => {
     analyze({
       workspace: options.workspace || "",
@@ -24,6 +25,7 @@ program
       allowLicenses: options.allowLicense || [],
       allowPackages: options.allowPackage || [],
       packageManager: options.packageManager || "",
+      configFilePath: options.config || "",
     });
   });
 
@@ -41,6 +43,7 @@ program
   .option("-o, --output <string>", "output file name")
   .option("--json", "output in JSON format")
   .option("-m, --packageManager <npm|pnpm>", "package manager used to extract licenses (default: auto detect)")
+  .option("-c, --config <path>", "config path. defaults to ./license-manager.config.js")
   .action((options) => {
     extract({
       workspace: options.workspace || "",
@@ -51,6 +54,7 @@ program
       output: options.output || "",
       json: !!options.json,
       packageManager: options.packageManager || "",
+      configFilePath: options.config || "",
     });
   });
 

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -18,10 +18,15 @@ export type ExtractArgs = {
   packageManager: string;
 };
 
-export const extract = async (cliArgs: ExtractArgs) => {
+export const extract = async ({
+  configFilePath,
+  ...cliArgs
+}: ExtractArgs & {
+  configFilePath?: string;
+}) => {
   console.log("🔪 Extract licenses...");
 
-  const config = await loadConfigScript();
+  const config = await loadConfigScript(configFilePath);
   const args = mergeConfig(cliArgs, config);
   const dependencies = await aggregate(
     args.packageManager,

--- a/src/functions/loadConfigScript.ts
+++ b/src/functions/loadConfigScript.ts
@@ -2,14 +2,16 @@ import fs from "fs";
 import path from "path";
 import { Config } from "../types";
 
-export const loadConfigScript = async (relativeConfigPath: string = ""): Promise<Partial<Config>> => {
-  const configPath = path.join(process.cwd(), relativeConfigPath || "license-manager.config.js");
+export const loadConfigScript = async (
+  relativeConfigPath: string = "license-manager.config.js"
+): Promise<Partial<Config>> => {
+  const configPath = path.join(process.cwd(), relativeConfigPath);
 
   if (!fs.existsSync(configPath)) {
     return {};
   }
 
-  console.log("💡 Detected license-manager.config.js");
+  console.log(`💡 Detected ${relativeConfigPath}`);
 
   const requirePath = path.relative(__dirname, configPath);
   const config = require(requirePath);


### PR DESCRIPTION
Add --config option for custom config file name.

## motivation
I want to use a name like license-manager.config.cjs when using cjs files with 'type: modules'.