### PR TITLE
fix: handle `licenses` property used in old packages

### DIFF
--- a/src/__tests__/depsUtils.test.ts
+++ b/src/__tests__/depsUtils.test.ts
@@ -8,6 +8,17 @@ describe("getLicense", () => {
   it("it should return license", () => {
     expect(getLicense(deps({ license: "MIT" }))).toBe("MIT");
     expect(getLicense(deps({ license: { type: "MIT", url: "https://example.com" } }))).toBe("MIT");
+    expect(getLicense(deps({ licenses: [{ type: "MIT", url: "https://example.com" }] }))).toBe("MIT");
+    expect(
+      getLicense(
+        deps({
+          licenses: [
+            { type: "MIT", url: "https://example.com/MIT" },
+            { type: "ISC", url: "https://example.com/ISC" },
+          ],
+        })
+      )
+    ).toBe("(MIT OR ISC)");
   });
 
   it("verify overrideLicense", () => {

--- a/src/functions/depsUtils.ts
+++ b/src/functions/depsUtils.ts
@@ -6,7 +6,16 @@ export const getLicense = (dep: Dependency, overrideLicense?: Config["overrideLi
     if (result) return result;
   }
   if (typeof dep.license === "string") return dep.license;
+  // Some old packages used license objects or licenses property containing an array.
+  // ref. https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license
   if (typeof dep.license === "object") return dep.license.type;
+  if (Array.isArray(dep.licenses)) {
+    if (dep.licenses.length > 1) {
+      const joined = dep.licenses.map((l) => l.type).join(" OR ");
+      return `(${joined})`;
+    }
+    return dep.licenses.at(0)?.type ?? "";
+  }
   return "";
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type RawDependency = {
   version: string;
   author?: string | { name: string; email?: string; url?: string };
   license?: string | { type: string; url: string };
+  licenses?: Array<{ type: string; url: string }>;
   repository?: { url: string };
   path: string;
 };


### PR DESCRIPTION
## Why

Some old packages used invalid styles for license notation. ([ref](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license))

- license object in the `license` property
- license objects array in the `licenses` property

The license-manager has already supported license objects in `license` but not array in `licenses`.

Some popular packages depend on such packages with invalid license notation, so I want to handle them correctly.
e.g. [npm-run-all](https://www.npmjs.com/package/npm-run-all) depends on [memorystream](https://www.npmjs.com/package/memorystream) or [undici](https://www.npmjs.com/package/undici/v/5.22.1) depends on [busboy](https://www.npmjs.com/package/busboy)

I also checked the pnpm behavior, and it handles the `licenses` property. ([ref](https://github.com/pnpm/pnpm/blob/main/reviewing/license-scanner/src/getPkgInfo.ts#L123))

## What

This PR adds a handler for the `licenses` property, as pnpm does.

- detect `licenses` property
- use `type` of the first element if `licenses` contains only an element
- use SPDX converted value if `licenses` contains multiple elements