### PR TITLE
fix: update version handling in getDependenciesForPnpm

### DIFF
--- a/src/functions/getDependencies.ts
+++ b/src/functions/getDependencies.ts
@@ -31,13 +31,19 @@ export const getDependenciesForPnpm = async (option: string, cwd: string, worksp
   const rawLicenses = JSON.parse(stdout) as RawPnpmLicenses;
   return Object.values(rawLicenses).flatMap((deps) =>
     deps.flatMap<RawDependency>((dep) => {
-      const { name, license, version } = dep;
+      const { name, license } = dep;
 
       if ("paths" in dep) {
-        return dep.paths.map((path) => ({ name, license, version, path }));
+        const { versions } = dep;
+        return dep.paths.map((path, index) => ({
+          name,
+          license,
+          version: versions[index],
+          path,
+        }));
       }
 
-      return [{ name, license, version, path: dep.path }];
+      return [{ name, license, version: dep.version, path: dep.path }];
     })
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type RawPnpmLicenses = Record<
       }
     | {
         name: string;
-        version: string;
+        versions: string[];
         paths: string[];
         license: string;
         author: string;


### PR DESCRIPTION
This pull request updates how dependency versions are handled in the PNPM license extraction logic to support multiple versions per dependency. The main change is to replace the single `version` field with a `versions` array, and update the mapping logic to correctly associate each path with its corresponding version.

Updates to dependency version handling:

* Changed the `RawPnpmLicenses` type in `src/types.ts` to use a `versions` array instead of a single `version` string for dependencies that have multiple paths.
* Updated the mapping logic in `getDependenciesForPnpm` in `src/functions/getDependencies.ts` to associate each path with its corresponding version from the `versions` array, ensuring accurate version information for each dependency path.…tiple versions

Reference
- logic: https://github.com/pnpm/pnpm/blob/9df09dd38e55424bdf5a77fab28397690ea8e7f0/reviewing/plugin-commands-licenses/src/outputRenderer.ts#L69-L83
- test case: https://github.com/pnpm/pnpm/blob/9df09dd38e55424bdf5a77fab28397690ea8e7f0/reviewing/plugin-commands-licenses/test/index.ts#L97-L109

